### PR TITLE
商品詳細ページ作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | status | integer  | null: false |
 | image  |  text   | null: false |
 | price  | integer | null: false |
-| shipping_days | integer | null: false |
+| shipping_day | integer | null: false |
 | shipping_origin | integer | null: false |
 | delivery_fee | integer | null: false |
 | user | references | null: false, foregin_key:true |

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_item, only: [:edit, :show]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -10,7 +11,14 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+  end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def delete
   end
 
   def create
@@ -32,6 +40,10 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :text, :category_id, :status_id, :price, :shipping_days_id, :shipping_origin_id, :delivery_fee_id, :user, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :category_id, :status_id, :price, :shipping_day_id, :shipping_origin_id, :delivery_fee_id, :user, :image).merge(user_id: current_user.id)
   end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def delete

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,7 @@ class Item < ApplicationRecord
   with_options numericality: { other_than: 1, message: "can't be blank" } do
     validates :category_id
     validates :status_id
-    validates :shipping_days_id
+    validates :shipping_day_id
     validates :shipping_origin_id
     validates :delivery_fee_id
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -33,7 +33,7 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -81,7 +81,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image, class:"item-box-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= "商品" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+      <span>¥<%= @item.price %>円</span>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,61 +24,59 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
-    </div>
-    <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
+    <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+      <div class="item-explain-box">
+        <span><%= @item.text %></span>
       </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
+      <table class="detail-table">
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @item.user.nickname %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= @item.category.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= @item.status.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= @item.delivery_fee.name  %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= @item.shipping_origin.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= @item.shipping_day.name %></td> 
+          </tr>
+        </tbody>
+      </table>
+      <div class="option">
+        <div class="favorite-btn">
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <span>お気に入り 0</span>
+        </div>
+        <div class="report-btn">
+          <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+          <span>不適切な商品の通報</span>
+        </div>
       </div>
     </div>
-  </div>
-  <%# /商品の概要 %>
-
+    <%# /商品の概要 %>
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>

--- a/db/migrate/20200826092202_create_items.rb
+++ b/db/migrate/20200826092202_create_items.rb
@@ -6,7 +6,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :category_id,         null: false
       t.integer :status_id,           null: false
       t.integer :price,            null: false
-      t.integer :shipping_days_id,    null: false
+      t.integer :shipping_day_id,    null: false
       t.integer :shipping_origin_id,  null: false
       t.integer :delivery_fee_id,     null: false
       t.references :user,          null: false, foregin_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2020_08_26_103646) do
     t.integer "category_id", null: false
     t.integer "status_id", null: false
     t.integer "price", null: false
-    t.integer "shipping_days_id", null: false
+    t.integer "shipping_day_id", null: false
     t.integer "shipping_origin_id", null: false
     t.integer "delivery_fee_id", null: false
     t.bigint "user_id", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     category_id          {2}
     status_id            {2}
     price                {4649}
-    shipping_days_id     {2}
+    shipping_day_id      {2}
     shipping_origin_id   {2}
     delivery_fee_id      {2}
     association :user                 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Item, type: :model do
       @item.valid?
       expect(@item.errors.full_messages).to include("Status can't be blank")
     end
-    it 'shipping_days_idを選択していないと保存できないこと' do
-      @item.shipping_days_id = 1
+    it 'shipping_day_idを選択していないと保存できないこと' do
+      @item.shipping_day_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping days can't be blank")
+      expect(@item.errors.full_messages).to include("Shipping day can't be blank")
     end
     it 'shipping_origin_idを選択していないと保存できないこと' do
       @item.shipping_origin_id = 1


### PR DESCRIPTION
#What
商品詳細表示機能
#WHY
ログアウト状態でも商品詳細ページを閲覧できること
出品者にしか商品の編集・削除のリンクが踏めないようになっていること
出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
商品出品時に登録した情報が見られるようになっていること

ログアウト状態でも
https://gyazo.com/36c0fabad6639d3d7aaee940da75261a
出品者にしか商品の編集・削除
https://gyazo.com/196d210c16ba517b10b5e164e2c441a2